### PR TITLE
Fix: duplicate declaration of "const elems"

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -3,17 +3,10 @@
   const $ = (selector, ctx = document) => [].slice.call(ctx.querySelectorAll(selector));
 
   document.addEventListener('DOMContentLoaded', () => {
-    const elems = $('[lang="mermaid"]');
+    const elems = $('[lang="mermaid"], .language-mermaid');
     elems.forEach(elem => {
       const codeElem = $('code', elem)[0];
       const code = codeElem.textContent;
-      elem.insertAdjacentHTML('afterend', `<div class="mermaid">${code}</div>`);
-      elem.style.display = 'none';
-    });
-
-    const elems = $('.language-mermaid');
-    elems.forEach(elem => {
-      const code = elem.textContent;
       elem.insertAdjacentHTML('afterend', `<div class="mermaid">${code}</div>`);
       elem.style.display = 'none';
     });


### PR DESCRIPTION
Issue: Variable "const elems" is declared twice in the same function. This was causing a javascript error that prevented the extension from working.
Fix: Use multiple selectors to run same code instead of multiple selections to run identical code.