### PR TITLE
FIX: elem is not defined at replaceChart

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -5,19 +5,22 @@
   document.addEventListener('DOMContentLoaded', () => {
     let elems = $('[lang="mermaid"]');
 
-    const replaceChart = (codeElem) => {
-      const code = codeElem.textContent;
+    const replaceChart = (elem, code) => {
       elem.insertAdjacentHTML('afterend', `<div class="mermaid">${code}</div>`);
       elem.style.display = 'none';
     };
 
     elems.forEach(elem => {
       const codeElem = $('code', elem)[0];
-      replaceChart(codeElem);
+      const code = codeElem.textContent;
+      replaceChart(elem, code);
     });
 
     elems = $('.language-mermaid');
-    elems.forEach(replaceChart);
+    elems.forEach(elem => {
+      const code = elem.textContent;
+      replaceChart(elem, code);
+    });
 
     window.mermaid.init();
   });


### PR DESCRIPTION
Hello,

I found that this extension does not work because error of

```
Uncaught ReferenceError: elem is not defined
    at replaceChart (content.js:10)
    at elems.forEach.elem (content.js:16)
    at Array.forEach (<anonymous>)
    at HTMLDocument.document.addEventListener (content.js:14)
```

This error seems to come from cb39c08dce1856b3397612846838ca01c3309a4a