### PR TITLE
Regenerate diagrams when altered

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -20,7 +20,8 @@
         "https://gist.github.com/*"
       ],
       "css": [
-        "diagrams.css"
+        "diagrams.css",
+        "on_change_animation.css"
       ],
       "js": [
         "mermaid.min.js",

--- a/extension/on_change_animation.css
+++ b/extension/on_change_animation.css
@@ -1,0 +1,14 @@
+/*
+  This trick for listening to changes by class was taken from
+  https://davidwalsh.name/detect-node-insertion.
+*/
+@keyframes mermaidDiagramCodeInserted {
+	from { opacity: 0.99; }
+	to { opacity: 1; }
+}
+
+/* The class list here determines what elements are detected. */
+.language-mermaid, [lang="mermaid"] {
+  animation-duration: 0.001s;
+  animation-name: mermaidDiagramCodeInserted;
+}


### PR DESCRIPTION
Why: So that the page does not need to be reloaded when the diagram is edited. Also renders the diagram when previewing markdown changes.