### PR TITLE
Add `new` Azure DevOps url format

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -7,6 +7,7 @@
   "minimum_chrome_version": "56",
   "permissions": [
     "https://*.visualstudio.com/*",
+    "https://dev.azure.com/*",
     "https://github.com/*",
     "https://gist.github.com/*",
     "https://bitbucket.org/*"
@@ -19,6 +20,7 @@
       "run_at": "document_start",
       "matches": [
         "https://*.visualstudio.com/*",
+        "https://dev.azure.com/*",
         "https://github.com/*",
         "https://gist.github.com/*",
         "https://bitbucket.org/*"


### PR DESCRIPTION
New accounts in Azure DevOps use `https://dev.azure.com/tenantname` instead of `https://tenantname.visualstudio.com` by default