### PR TITLE
fix: visibility in dark mode

### DIFF
--- a/extension/diagrams.css
+++ b/extension/diagrams.css
@@ -1,5 +1,6 @@
 .mermaid {
   padding-bottom: 5rem;
+  background-color: white;
 }
 
 .actor {


### PR DESCRIPTION
set background colour as white in CSS so that diagrams will be visible
clearly even in dark mode.